### PR TITLE
Fix/Workaround for lua error by Korean localization

### DIFF
--- a/Localization/koKR.lua
+++ b/Localization/koKR.lua
@@ -24,6 +24,7 @@ SOFTWARE.
 local ADDON, _ = ...
 
 local L = LibStub("AceLocale-3.0"):NewLocale(ADDON, "koKR", false)
+if not L then return end
 
 -- UI elements
 L["TAB_TITLE"] = "영혼형상"
@@ -121,11 +122,13 @@ L["Mushroom Network"] = "버섯 연결망"
 L["Marasmius"] = "마라스미우스"
 L["Paragon reward."] = "확고한 동맹 보급품."
 L["Soulshape"] = "영혼형상"
+L["Crittershape"] = true
 L["Pilgrim's Bounty"] = "순례자의 감사절"
 L["Covenant Callings reward chests"] = "성약의 단 부름 퀘스트 보상 상자"
 
-L["Normal or Heroic"] = "일반 혹은 영웅"
+L["Normal"] = true
 L["Heroic"] = "영웅"
+L["Mythic"] = true
 L["Hardmode"] = "하드모드"
 L["Any"] = "어느"
 


### PR DESCRIPTION
Hey!
The Korean Localization causes an error. I fixed this and added some missing keys (but with "true" instead of Korean strings – didn't want to blindly copy the text from Google Translator).

Please feel free to reject the pull request and fix it in another way – I primarily wanted to document the error. ;)

---------------------------

Added conditional for unused locale identifier

Added 
	- "Crittershape" (but without Korean string)
	- "Normal" (but without Korean string)
	- "Mythic" (but without Korean string)

Removed
	- "Normal or Heroic"