### PR TITLE
Fix for addon blocked error when opening while in combat

### DIFF
--- a/SoulshapeJournal.toc
+++ b/SoulshapeJournal.toc
@@ -1,4 +1,4 @@
-## Interface: 100005
+## Interface: 100007
 ## Version: @project-version@
 ## Title: Soulshape Journal |T3586268:0|t
 ## Notes: Displays Nightfae shoulshapes as a collection journal
@@ -7,6 +7,8 @@
 ## X-Website: https://github.com/christopheml/SoulshapeJournal/
 ## X-Curse-Project-ID: 550045
 ## SavedVariables: SoulshapeJournalDB
+## LoadOnDemand: 1
+## LoadWith: Blizzard_Collections
 
 Libs\LibStub\LibStub.lua
 Libs\AceLocale-3.0\AceLocale-3.0.xml

--- a/UI/SoulshapeJournal.lua
+++ b/UI/SoulshapeJournal.lua
@@ -254,6 +254,7 @@ local function CreateTab(panel)
     tab.frame = panel
 
     tab.OnSelect = function()
+        if InCombatLockdown() then return end
         -- Some addons aren't aware that we exist and won't hide themselves correctly when
         -- we show up. We'll circumvent this by telling the UI we're selecting another tab
         -- from the CollectionsJournal immediately before switching to ours, which causes


### PR DESCRIPTION
        -- Some addons aren't aware that we exist and won't hide themselves correctly when
        -- we show up. We'll circumvent this by telling the UI we're selecting another tab
        -- from the CollectionsJournal immediately before switching to ours, which causes
        -- those addons to hide themselves gracefully.
        -- The chosen tab is the Heirlooms Journal because we don't expect any popular
        -- addon to modify its frame. If it's the case, well, we're screwed.
        -- If you read this and you have a better technique to attach tabs to the
        -- collection journal, please message me.

I don't have a better technique, but I did find a problem with your implementation: if we are in combat when we open the collections UI and switch to your tab, we get an Lua error - MountJournal:SetShown called while the frame is protected due to combat.

This adds an InCombat check. I figure problems with another addon is preferable to an addon error causing this one to not work at all. All the player needs to do is get out of combat and switch to the tab again if another addon isn't displayed correctly.